### PR TITLE
Add some flavor to Ásatrú

### DIFF
--- a/common/interest_group_traits/fm_devout_traits.txt
+++ b/common/interest_group_traits/fm_devout_traits.txt
@@ -1,0 +1,29 @@
+ig_trait_sons_of_ragnarok = {
+	icon = "gfx/interface/icons/ig_trait_icons/patriotic_fervor.dds"
+	min_approval = loyal
+	
+	modifier = {
+		unit_morale_recovery_mult = 0.1
+		unit_morale_loss_mult = -0.1
+	}
+}
+
+ig_trait_blessed_by_aesir = {
+	icon = "gfx/interface/icons/ig_trait_icons/divine_right.dds"
+	min_approval = happy
+	
+	modifier = {
+		state_loyalists_from_political_movements_mult = 0.05
+	}
+}
+
+ig_trait_nio = {
+	icon = "gfx/interface/icons/ig_trait_icons/pious_fiction.dds"
+	max_approval = unhappy
+	
+	modifier = {
+		unit_morale_recovery_mult = -0.05
+		unit_morale_loss_mult = 0.05
+		state_radicals_from_political_movements_mult = 0.05
+	}
+}

--- a/common/interest_group_traits/fm_devout_traits.txt
+++ b/common/interest_group_traits/fm_devout_traits.txt
@@ -13,7 +13,7 @@ ig_trait_blessed_by_aesir = {
 	min_approval = happy
 	
 	modifier = {
-		state_loyalists_from_political_movements_mult = 0.05
+		state_loyalists_from_political_movements_mult = 0.1
 	}
 }
 

--- a/common/interest_groups/00_devout.txt
+++ b/common/interest_groups/00_devout.txt
@@ -142,6 +142,14 @@
 					}
 				}
 			}
+			else_if = {
+				limit = {
+					owner = { country_has_state_religion = rel:norsp }
+				}
+				set_ig_trait = ig_trait:ig_trait_nio
+				set_ig_trait = ig_trait:ig_trait_blessed_by_aesir
+				set_ig_trait = ig_trait:ig_trait_sons_of_ragnarok
+			}
 			else = {
 				set_ig_trait = ig_trait:ig_trait_pious_fiction
 				set_ig_trait = ig_trait:ig_trait_divine_right

--- a/localization/english/interest_groups/fm_interest_group_traits_l_english.yml
+++ b/localization/english/interest_groups/fm_interest_group_traits_l_english.yml
@@ -1,0 +1,9 @@
+﻿l_english:
+
+# Asatru IGs
+ig_trait_sons_of_ragnarok: "Sons of Ragnarök"
+ig_trait_sons_of_ragnarok_desc: "We shall not wane into obscurity without a fight! The end times are near. Our people must prove their worth if they are ever to enter Valhalla!"
+ig_trait_blessed_by_aesir: "Blessed by the Æsir"
+ig_trait_blessed_by_aesir_desc: "The gods smile upon us, and their favor fills our hearts with purpose. As long as we honor the old ways, our people shall know prosperity and joy."
+ig_trait_nio: "Níð"
+ig_trait_nio_desc: "Honorless wretches sit upon the high seats, unworthy of our loyalty! Why should we follow those who have forsaken the sacred bonds of trust and virtue?"

--- a/localization/english/religion_l_english.yml
+++ b/localization/english/religion_l_english.yml
@@ -9,7 +9,7 @@
  jewish: "Jewish"
  mahayana: "Mahayana"
  baal: "Canaanite"
- norsp: "Norse Pagan"
+ norsp: "Ásatrú"
  gelugpa: "Gelugpa"
  theravada: "Theravada"
  hindu: "Hindu"


### PR DESCRIPTION
This just adds some flavor to the Norse. The effects of the new traitsare as follows:

- Sons of Ragnarök: The inverse of "Divided Ranks", this represents your people ready to die for you, no matter the odds. After all, this is the best way to get into Valhalla.
- Blessed by the Æsir: This represents the idea that your populace are blessed by the gods themselves. This provides extra loyalty from political movements, effectively a weaker form of "Master of the House".
- Níð: Basically representing how important honor is in the traditional Norse religion, this combines the effects of "Of the Sovereign Alone" and "Divided Ranks" to simulate your people ready to desert on a whim, and rebel against your dishonorable ways.

In addition, "Norse Paganism" is renamed to "Ásatrú", as it is in CK3.